### PR TITLE
compatibility with Python < 3.10

### DIFF
--- a/src/rutube.py
+++ b/src/rutube.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import abc
 import enum
 import json


### PR DESCRIPTION
Added from __future__ import annotations for compatibility with Python < 3.10, enabling | syntax for union types.

Great project!